### PR TITLE
Add "Toggle Comments" functionality

### DIFF
--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Comments</string>
+	<key>scope</key>
+	<string>source.jade</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>//- </string>
+			</dict>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>D2ABB2E0-EB25-11E0-9572-0800200C9A66</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -10,6 +10,7 @@
 		<string>45F19BDD-2A4D-4848-83D5-E5F1A7FF4726</string>
 		<string>4E2866A2-7FAE-4980-84E1-0E8AAB7C36FB</string>
 		<string>FF542D1A-4247-4240-8348-DB30EB477256</string>
+	  <string>D2ABB2E0-EB25-11E0-9572-0800200C9A66</string>
 	</array>
 	<key>uuid</key>
 	<string>93D6D9C3-67F2-4C06-B3B3-BF872579B44F</string>


### PR DESCRIPTION
I realized that this bundle didn't support TextMate's cmd-/ "toggle comments" functionality, so I added it. I opted for lines to be commented out in the //- style as opposed to the // style, so that the resulting markup is as clean as possible.

Thanks!
