### PR TITLE
Improved the regular expression that delimits coffeescript in jade

### DIFF
--- a/Syntaxes/Jade.tmLanguage
+++ b/Syntaxes/Jade.tmLanguage
@@ -141,7 +141,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>^(?!\1\s+)</string>
+			<string>^(?!\1\s+)(?=\s*.)</string>
 			<key>name</key>
 			<string>meta.filter.coffee.jade</string>
 			<key>patterns</key>


### PR DESCRIPTION
Blocks of coffeescript in a jade file will only stop coffeescript syntax highlighting when it has read a line with less or equal whitespace indentation as coffeescript that actually has text on the line.
Before, it was finding any line with any amount of whitespace less, regardless of whether that line had text. If your editor trimmed trailing whitespace, then only the first bit of coffeescript had proper syntax coloring, and the rest had jade coloring.
